### PR TITLE
avoid exception when no affiliate_partner is nil

### DIFF
--- a/app/models/user_decorator.rb
+++ b/app/models/user_decorator.rb
@@ -4,7 +4,7 @@ User.class_eval do
   has_one :affiliate_partner, :class_name => "Affiliate", :foreign_key => "user_id"
 
   def partner
-    affiliate_partner.partner
+    affiliate_partner&.partner
   end
   
   def ref_id


### PR DESCRIPTION
[asana](https://app.asana.com/0/1202737029606289/1205844737567276/f)

silly little detail that avoids throwing errors when a user has no affiliates and we try to access its partner.